### PR TITLE
Translation of QGIS project content in Lizmap Web Client

### DIFF
--- a/translation/README.md
+++ b/translation/README.md
@@ -4,8 +4,8 @@ In this folder there are:
 * a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
 * a javascript file which translate the project content in Lizmap-Web-Client according to the browser language
 
-The python script (get_translatable_string.py)
-----------------------------------------------
+## The python script (get_translatable_string.py)
+
 This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrieved string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:
 
 ```json
@@ -28,13 +28,13 @@ The translation has to be provided manually by editing the file and putting the 
 * It requires the .cfg file created with the lizmap plugin.
 * For further details about the script see the comments in the code.
 
-The js script (translation.js)
-----------------------------------------------
+## The js script (translation.js)
+
 This javascript script translates layers and groups names, the title of the project, the print layouts names and the aliases or fileds names according to the language of the browser and using the json file created with the python script *get_translatable_string.py*
 If a translated string is provided in the json file the original string is translated, otherwise the original string is shown in lizmap web client.
 The json file must be saved in the media folder which needs to be available from the web. Therefore it is necessary to create 
 a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository.
-The javascript retrieves the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. *$("div#header div#title h1")*). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
+The javascript retrieves the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. `$("div#header div#title h1")`). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
 
 At the moment the script translates:
 * layers and groups name in the layer tree
@@ -54,5 +54,5 @@ At the moment the script translates:
 **NB.**
 * The javascript file has to be saved in the media/js folder.
 * Change the path to the .json file according to your media folder path (using the link to media folder previously created).
-* If something is not properly translated check the html selector (e.g. *$("div#header div#title h1")*), they can be different depending on your lizmap properties (e.g the container of the popup), or the json file.
+* If something is not properly translated check the html selector (e.g. `$("div#header div#title h1")`), they can be different depending on your lizmap properties (e.g the container of the popup), or the json file.
 * For further details about the script see the comments in the code.

--- a/translation/README.md
+++ b/translation/README.md
@@ -1,2 +1,4 @@
-# translation folder
-Python and javascript files to translate layers, groups, aliases or field and print layout names in lizmap webclient according to the browser language
+# Translation
+In this folder there are:
+1* a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
+2* a javascript file which translate the project content in lizmapwebclient according to the browser language

--- a/translation/README.md
+++ b/translation/README.md
@@ -6,11 +6,11 @@ In this folder there are:
 
 The python script (get_translatable_string.py)
 ----------------------------------------------
-This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrived string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:
+This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrieved string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:
 
 *{"Original layer name": "", "Original group name": "", ..}*
 
-The translation has to be provided manually by editing the file and putting the translated string in the double quotes. Following an example of the translated json:
+The translation has to be provided manually by editing the file and putting the translated string in the double-quotes. Following an example of the translated json:
 
 *{"Original layer name": "Translated layer name", "Original group name": "Translated group name", ..}*
 
@@ -23,9 +23,9 @@ The js script (translation.js)
 ----------------------------------------------
 This javascript script translates layers and groups names, the title of the project, the print layouts names and the aliases or fileds names according to the language of the browser and using the json file created with the python script *get_translatable_string.py*
 If a translated string is provided in the json file the original string is translated, otherwise the original string is shown in lizmap web client.
-The json file must be saved in the media folder which need to be available from the web. Therefore it is necessary to create 
+The json file must be saved in the media folder which needs to be available from the web. Therefore it is necessary to create 
 a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository.
-The javascript retrives the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. *$("div#header div#title h1")*). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
+The javascript retrieves the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. *$("div#header div#title h1")*). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
 
 At the moment the script translates:
 * layers and groups name in the layer tree

--- a/translation/README.md
+++ b/translation/README.md
@@ -13,10 +13,15 @@ This python script retrieves all possible translatable strings (layers name, gro
     "Original layer name": "",
     "Original group name": "",
 }
-
+```
 The translation has to be provided manually by editing the file and putting the translated string in the double-quotes. Following an example of the translated json:
 
-*{"Original layer name": "Translated layer name", "Original group name": "Translated group name", ..}*
+```json
+{
+    "Original layer name": "Translated layer name", 
+    "Original group name": "Translated group name",
+}
+```
 
 **NB.**
 * The script has to be run from the QGIS python console of the project.

--- a/translation/README.md
+++ b/translation/README.md
@@ -8,8 +8,13 @@ The python script (get_translatable_string.py)
 ----------------------------------------------
 This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrived string and the value should contain the translation of the string. Following an example of the json structure:
 
-'{"original layer name": "", "Original group name": "", ..}'
+*{"Original layer name": "", "Original group name": "", ..}*
 
-The translation has to be provided manually by editing the file and putting the translated string in the double quotes.
-The script has to be run from the qgis python console of the project.
-It requires the .cfg file created with the lizmap plugin
+The translation has to be provided manually by editing the file and putting the translated string in the double quotes. Following an example of the translated json:
+
+*{"Original layer name": "Translated layer name", "Original group name": "Translated group name", ..}*
+
+**NB.**
+* The script has to be run from the QGIS python console of the project.
+* It requires the .cfg file created with the lizmap plugin.
+* For further details about the script see the comments in the code.

--- a/translation/README.md
+++ b/translation/README.md
@@ -6,7 +6,7 @@ In this folder there are:
 
 ## The python script (get_translatable_string.py)
 
-This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrieved string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:
+This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file for each language specified in a list (e.g. translation_fr.json, translation_en.json, etc.). The key of the json file is the retrieved string and the value should contain the translation of the string. The json files are automatically saved in the media folder. Following an example of the json structure:
 
 ```json
 {
@@ -32,9 +32,9 @@ The translation has to be provided manually by editing the file and putting the 
 
 This javascript script translates layers and groups names, the title of the project, the print layouts names and the aliases or fileds names according to the language of the browser and using the json file created with the python script *get_translatable_string.py*
 If a translated string is provided in the json file the original string is translated, otherwise the original string is shown in lizmap web client.
-The json file must be saved in the media folder which needs to be available from the web. Therefore it is necessary to create 
+The json files must be saved in the media folder which needs to be available from the web. Therefore it is necessary to create 
 a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository.
-The javascript retrieves the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. `$("div#header div#title h1")`). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
+The javascript retrieves the original string (key) and the translated string (value) from the proper json file that is automatically loaded depending on the language of the browser. Then for each key found in the json it checks the text of the provided html selector (e.g. `$("div#header div#title h1")`). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
 
 At the moment the script translates:
 * layers and groups name in the layer tree
@@ -53,6 +53,5 @@ At the moment the script translates:
 
 **NB.**
 * The javascript file has to be saved in the media/js folder.
-* Change the path to the .json file according to your media folder path (using the link to media folder previously created).
 * If something is not properly translated check the html selector (e.g. `$("div#header div#title h1")`), they can be different depending on your lizmap properties (e.g the container of the popup), or the json file.
 * For further details about the script see the comments in the code.

--- a/translation/README.md
+++ b/translation/README.md
@@ -2,7 +2,7 @@
 In this folder there are:
 
 * a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
-* a javascript file which translate the project content in lizmapwebclient according to the browser language
+* a javascript file which translate the project content in Lizmap-Web-Client according to the browser language
 
 The python script (get_translatable_string.py)
 ----------------------------------------------
@@ -44,6 +44,6 @@ At the moment the script translates:
 
 **NB.**
 * The javascript file has to be saved in the media/js folder.
-* Change the path to the .json file according to your media folder path.
+* Change the path to the .json file according to your media folder path (using the link to media folder previously created).
 * If something is not properly translated check the html selector (e.g. *$("div#header div#title h1")*), they can be different depending on your lizmap properties (e.g the container of the popup), or the json file.
 * For further details about the script see the comments in the code.

--- a/translation/README.md
+++ b/translation/README.md
@@ -8,7 +8,11 @@ The python script (get_translatable_string.py)
 ----------------------------------------------
 This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrieved string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:
 
-*{"Original layer name": "", "Original group name": "", ..}*
+```json
+{
+    "Original layer name": "",
+    "Original group name": "",
+}
 
 The translation has to be provided manually by editing the file and putting the translated string in the double-quotes. Following an example of the translated json:
 

--- a/translation/README.md
+++ b/translation/README.md
@@ -1,4 +1,5 @@
 # Translation
 In this folder there are:
+
 1* a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
 2* a javascript file which translate the project content in lizmapwebclient according to the browser language

--- a/translation/README.md
+++ b/translation/README.md
@@ -6,7 +6,7 @@ In this folder there are:
 
 The python script (get_translatable_string.py)
 ----------------------------------------------
-This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrived string and the value should contain the translation of the string. Following an example of the json structure:
+This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrived string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:
 
 *{"Original layer name": "", "Original group name": "", ..}*
 
@@ -17,4 +17,33 @@ The translation has to be provided manually by editing the file and putting the 
 **NB.**
 * The script has to be run from the QGIS python console of the project.
 * It requires the .cfg file created with the lizmap plugin.
+* For further details about the script see the comments in the code.
+
+The js script (translation.js)
+----------------------------------------------
+This javascript script translates layers and groups names, the title of the project, the print layouts names and the aliases or fileds names according to the language of the browser and using the json file created with the python script *get_translatable_string.py*
+If a translated string is provided in the json file the original string is translated, otherwise the original string is shown in lizmap web client.
+The json file must be saved in the media folder which need to be available from the web. Therefore it is necessary to create 
+a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository.
+The javascript retrives the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. *$("div#header div#title h1")*). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.
+
+At the moment the script translates:
+* layers and groups name in the layer tree
+* layers name in the baselayer menu
+* layers name in the editing tool menu
+* layers name in the selection tool menu
+* layouts name in the print tool menu
+* layers and groups name in the attribute layer tool
+* the title of the project
+* layers name in the edition form
+* aliases or fields name in the edition form
+* layers name in the popup
+* aliases or fields name in the popup
+* the layer name shown in the location tool
+* the content of the layer information sub-dock
+
+**NB.**
+* The javascript file has to be saved in the media/js folder.
+* Change the path to the .json file according to your media folder path.
+* If something is not properly translated check the html selector (e.g. *$("div#header div#title h1")*), they can be different depending on your lizmap properties (e.g the container of the popup), or the json file.
 * For further details about the script see the comments in the code.

--- a/translation/README.md
+++ b/translation/README.md
@@ -1,0 +1,2 @@
+# translation folder
+Python and javascript files to translate layers, groups, aliases or field and print layout names in lizmap webclient according to the browser language

--- a/translation/README.md
+++ b/translation/README.md
@@ -1,5 +1,15 @@
 # Translation
 In this folder there are:
 
-1* a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
-2* a javascript file which translate the project content in lizmapwebclient according to the browser language
+* a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
+* a javascript file which translate the project content in lizmapwebclient according to the browser language
+
+The python script (get_translatable_string.py)
+----------------------------------------------
+This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrived string and the value should contain the translation of the string. Following an example of the json structure:
+
+'{"original layer name": "", "Original group name": "", ..}'
+
+The translation has to be provided manually by editing the file and putting the translated string in the double quotes.
+The script has to be run from the qgis python console of the project.
+It requires the .cfg file created with the lizmap plugin

--- a/translation/get_translatable_string.py
+++ b/translation/get_translatable_string.py
@@ -5,14 +5,19 @@
 # This python script retrieves all possible translatable strings (layers name, groups name,
 # layouts name, fields or aliases name, etc.) from the project and the .cfg file and saves a
 # json file in which the key is the retrived string and the value should contain the translation
-# of the string. The translation has to be provided manually by editing the file.
-# The script has to be run from the qgis python console of the project.
-# It requires the .cfg file created with the lizmap plugin
+# of the string. ATTENTION: this script uses the attributeAliases() method to retrieve fields
+# names/aliases. This method does not read aliases of layers added during the active session
+# of QGIS. If you add layers in the project, you have to save and close the project, open
+# the project again and then launch this script.
+# The translation has to be provided manually by editing the json file.
+# This script has to be run from the qgis python console of the project.
+# It requires the .cfg file created with the lizmap plugin.
 #############################################################################################
 
 import json
 import os
 
+sel_gr = 'ConcertEaux' #the name of the group containing the layers from which fields name/aliases are retrieved, to be commented if not necessary 
 lyrs = []
 lyrs_tmp = []
 title_dict = {}
@@ -23,6 +28,7 @@ translation = {}
 fields_dict = {}
 diff_dict = {}
 projectInstance = QgsProject.instance()
+root = projectInstance.layerTreeRoot()
 
 #retrieves layers and groups titles and abstracts from the .cfg file
 prjName = projectInstance.fileName() #the project .qgs file
@@ -60,8 +66,7 @@ info_dict['\n          {}\n        '.format(projectInstance.readEntry('WMSServic
 #and put them in the related dictionary.
 #It works over the whole layer tree too. Comment the lines related to the specified group
 #to retrieve the alias/fields name of all vector layers in the project
-root = projectInstance.layerTreeRoot()
-sel_gr = 'ConcertEaux' #the name of the desired group, to be commented if not necessary 
+
 for child in root.children():
     if isinstance(child, QgsLayerTreeGroup):
         if child.name() == sel_gr: #to be commented if not necessary 

--- a/translation/get_translatable_string.py
+++ b/translation/get_translatable_string.py
@@ -49,7 +49,7 @@ for l in projectLayoutManager.layouts():
 info_dict['\n          {}\n        '.format(projectInstance.readEntry('WMSServiceTitle', '')[0])] = ""
 
 #retrieves the aliases or the fields names of all vector layer in a specified group
-#and put them in the related project.
+#and put them in the related dictionary.
 #It works over the whole layer tree too. Comment the lines related to the specified group
 #to retrieve the alias/fields name of all vector layers in the project
 root = projectInstance.layerTreeRoot()

--- a/translation/get_translatable_string.py
+++ b/translation/get_translatable_string.py
@@ -4,11 +4,11 @@
 #############################################################################################
 # This python script retrieves all possible translatable strings (layers name, groups name,
 # layouts name, fields or aliases name, etc.) from the project and the .cfg file and saves a
-# json file in which the key is the retrived string and the value should contain the translation
-# of the string. ATTENTION: this script uses the attributeAliases() method to retrieve fields
-# names/aliases. This method does not read aliases of layers added during the active session
-# of QGIS. If you add layers in the project, you have to save and close the project, open
-# the project again and then launch this script.
+# json file, for eache specified language, in which the key is the retrived string and the
+# value should contain the translation of the string. ATTENTION: this script uses the
+# attributeAliases() method to retrieve fields names/aliases. This method does not read
+# aliases of layers added during the active sessionof QGIS. If you add layers in the project,
+# you have to save and close the project, open the project again and then launch this script.
 # The translation has to be provided manually by editing the json file.
 # This script has to be run from the qgis python console of the project.
 # It requires the .cfg file created with the lizmap plugin.
@@ -18,6 +18,7 @@ import json
 import os
 
 sel_gr = 'ConcertEaux' #the name of the group containing the layers from which fields name/aliases are retrieved, to be commented if not necessary 
+languages = ['fr', 'en'] #the list of the desired language ID Code. This code must be the same provided in the translation.js for the langId variable.
 lyrs = []
 lyrs_tmp = []
 title_dict = {}
@@ -33,7 +34,6 @@ root = projectInstance.layerTreeRoot()
 #retrieves layers and groups titles and abstracts from the .cfg file
 prjName = projectInstance.fileName() #the project .qgs file
 prjPath = projectInstance.homePath() #the project .qgs folder
-jsonFilePath = '{}/media/translation.json'.format(prjPath) #the output .json file
 
 json_file = '{}.cfg'.format(prjName) #the .cfg file
 if os.path.exists(json_file): #check if the file esists
@@ -95,27 +95,29 @@ translation = {**title_dict, **abstract_dict, **layout_dict, **info_dict, **fiel
 
 #creates a .json file in the media folder with the dictionary containing all strings to be translated
 #if the .json file already exists, only possible new string found will be added to the .json file
-if os.path.exists(jsonFilePath):
-    with open(jsonFilePath, 'r') as jf:
-        exist_dict = json.load(jf)
-    for key_t, value_t in translation.items():
-        if not key_t in exist_dict:
-            diff_dict[key_t] = ""
-    if diff_dict != {}:
-        exist_dict.update(diff_dict)
+for lang in languages:
+    jsonFilePath = '{}/media/translation_{}.json'.format(prjPath, lang) #the output .json file
+    if os.path.exists(jsonFilePath):
+        with open(jsonFilePath, 'r') as jf:
+            exist_dict = json.load(jf)
+        for key_t, value_t in translation.items():
+            if not key_t in exist_dict:
+                diff_dict[key_t] = ""
+        if diff_dict != {}:
+            exist_dict.update(diff_dict)
+            try:
+                with open(jsonFilePath, 'w', encoding='utf-8') as fp:
+                    json.dump(exist_dict, fp, ensure_ascii=False, indent=4)
+                print('The translation_{}.json file has been updated'.format(lang))
+            except:
+                print('Unable to update the translation_{}.json file'.format(lang))
+        else:
+            print('The translation_{}.json file already contains all translatable strings. It will not be updated.'.format(lang))
+    else:
         try:
             with open(jsonFilePath, 'w', encoding='utf-8') as fp:
-                json.dump(exist_dict, fp, ensure_ascii=False, indent=4)
-            print('The .json file has been updated')
+                json.dump(translation, fp, ensure_ascii=False, indent=4)
+            print('The translation_{}.json file has been saved'.format(lang))
         except:
-            print('Unable to update the .json file')
-    else:
-        print('The .json file already contains all translatable strings. It will not be updated.')
-else:
-    try:
-        with open(jsonFilePath, 'w', encoding='utf-8') as fp:
-            json.dump(translation, fp, ensure_ascii=False, indent=4)
-        print('The .json file has been saved')
-    except:
-        print('Unable to save the .json file to "{}"'.format(jsonFilePath))
-        print('Check that the folder exists.')
+            print('Unable to save the translation_{}.json file to "{}"'.format(lang, jsonFilePath))
+            print('Check that the folder exists.')

--- a/translation/get_translatable_string.py
+++ b/translation/get_translatable_string.py
@@ -105,7 +105,7 @@ if os.path.exists(jsonFilePath):
         exist_dict.update(diff_dict)
         try:
             with open(jsonFilePath, 'w', encoding='utf-8') as fp:
-                json.dump(exist_dict, fp, ensure_ascii=False)
+                json.dump(exist_dict, fp, ensure_ascii=False, indent=4)
             print('The .json file has been updated')
         except:
             print('Unable to update the .json file')
@@ -114,7 +114,8 @@ if os.path.exists(jsonFilePath):
 else:
     try:
         with open(jsonFilePath, 'w', encoding='utf-8') as fp:
-            json.dump(translation, fp, ensure_ascii=False)
+            json.dump(translation, fp, ensure_ascii=False, indent=4)
         print('The .json file has been saved')
     except:
-        print('Unable to save the .json file')
+        print('Unable to save the .json file to "{}"'.format(jsonFilePath))
+        print('Check that the folder exists.')

--- a/translation/get_translatable_string.py
+++ b/translation/get_translatable_string.py
@@ -1,9 +1,15 @@
-## This python script retrieves all possible translatable strings (layers name, groups name,
-#layouts name, fields or aliases name, etc.) from the project and the .cfg file and saves a
-#json file in which the key is the retrived string and the value should contain the translation
-#of the string. The translation has to be provided manually by editing the file.
-#The script has to be run from the qgis python console of the project.
-#It requires the .cfg file created with the lizmap plugin
+#! usr/bin/env python
+# Author: Roberta Fagandini roberta.fagandini@gter.it 
+# GTER copyleft 2020 - https://creativecommons.org/licenses/by/4.0/
+#############################################################################################
+# This python script retrieves all possible translatable strings (layers name, groups name,
+# layouts name, fields or aliases name, etc.) from the project and the .cfg file and saves a
+# json file in which the key is the retrived string and the value should contain the translation
+# of the string. The translation has to be provided manually by editing the file.
+# The script has to be run from the qgis python console of the project.
+# It requires the .cfg file created with the lizmap plugin
+#############################################################################################
+
 import json
 import os
 
@@ -17,7 +23,7 @@ translation = {}
 fields_dict = {}
 projectInstance = QgsProject.instance()
 
-#retrieves layers and groups titels and abstracts from the .cfg file
+#retrieves layers and groups titles and abstracts from the .cfg file
 prjName = projectInstance.fileName() #the project .qgs file
 prjPath = projectInstance.homePath() #the project .qgs folder
 
@@ -42,9 +48,9 @@ projectLayoutManager = projectInstance.layoutManager()
 for l in projectLayoutManager.layouts():
     layout_dict[l.name()] = ""
 
-#retrives the title of the project defined in the Qgis server tab of the project properties
+#retrieves the title of the project defined in the Qgis server tab of the project properties
 #and put it in the related dictionary
-#The sub title i.e. the name of the repository cannot be retrived from the project or the .cfg file
+#The sub title i.e. the name of the repository cannot be retrieved from the project or the .cfg file
 #hence it has to be translated directly in the translation.js file
 info_dict['\n          {}\n        '.format(projectInstance.readEntry('WMSServiceTitle', '')[0])] = ""
 

--- a/translation/get_translatable_string.py
+++ b/translation/get_translatable_string.py
@@ -1,0 +1,86 @@
+## This python script retrieves all possible translatable strings (layers name, groups name,
+#layouts name, fields or aliases name, etc.) from the project and the .cfg file and saves a
+#json file in which the key is the retrived string and the value should contain the translation
+#of the string. The translation has to be provided manually by editing the file.
+#The script has to be run from the qgis python console of the project.
+#It requires the .cfg file created with the lizmap plugin
+import json
+import os
+
+lyrs = []
+lyrs_tmp = []
+title_dict = {}
+abstract_dict = {}
+layout_dict = {}
+info_dict = {}
+translation = {}
+fields_dict = {}
+projectInstance = QgsProject.instance()
+
+#retrieves layers and groups titels and abstracts from the .cfg file
+prjName = projectInstance.fileName() #the project .qgs file
+prjPath = projectInstance.homePath() #the project .qgs folder
+
+json_file = '{}.cfg'.format(prjName) #the .cfg file
+if os.path.exists(json_file): #check if the file esists
+    print('Found!')
+    #reads the .cfg file
+    cfg_file = open(json_file, 'r')
+    json_file_reader = cfg_file.read()
+    sjson = json.loads(json_file_reader)
+    #gets title and abstract values from the layers key and put them in the related dictionary
+    json_layers = sjson['layers']
+    for key, value in json_layers.items():
+        title_dict[value['title']] = ""
+        if value['abstract'] != "":
+            abstract_dict[value['abstract']] = ""
+else:
+    print('Not found!')
+
+#retrives the names of the defined print layouts and put them in the related dictionary
+projectLayoutManager = projectInstance.layoutManager()
+for l in projectLayoutManager.layouts():
+    layout_dict[l.name()] = ""
+
+#retrives the title of the project defined in the Qgis server tab of the project properties
+#and put it in the related dictionary
+#The sub title i.e. the name of the repository cannot be retrived from the project or the .cfg file
+#hence it has to be translated directly in the translation.js file
+info_dict['\n          {}\n        '.format(projectInstance.readEntry('WMSServiceTitle', '')[0])] = ""
+
+#retrieves the aliases or the fields names of all vector layer in a specified group
+#and put them in the related project.
+#It works over the whole layer tree too. Comment the lines related to the specified group
+#to retrieve the alias/fields name of all vector layers in the project
+root = projectInstance.layerTreeRoot()
+sel_gr = 'ConcertEaux' #the name of the desired group, to be commented if not necessary 
+for child in root.children():
+    if isinstance(child, QgsLayerTreeGroup):
+        if child.name() == sel_gr: #to be commented if not necessary 
+            for gr in child.children():
+                if isinstance(gr, QgsLayerTreeGroup):
+                    lyrs_tmp = gr.findLayers()
+                    for lt in lyrs_tmp:
+                        if isinstance(lt.layer(), QgsVectorLayer):
+                            lyrs.append(lt)
+                elif isinstance(gr.layer(), QgsVectorLayer):
+                    lyrs.append(gr)
+for l in lyrs:
+    alias = l.layer().attributeAliases()
+    #put the alias or the field name, if the alias is not defined, in the related dictionary
+    for key, value in alias.items():
+        if value != '':
+            fields_dict[value] = ""
+        else:
+            fields_dict[key] = ""
+
+##merge all dictionaries in a new one
+translation = {**title_dict, **abstract_dict, **layout_dict, **info_dict, **fields_dict}
+
+#creates a .json file in the media folder with the dictionary containing all strings to be translated
+try:
+    with open('{}/media/translation.json'.format(prjPath), 'w', encoding='utf-8') as fp:
+        json.dump(translation, fp, ensure_ascii=False)
+    print('The .json file has been saved')
+except:
+    print('Unable to save the .json file')

--- a/translation/translation.js
+++ b/translation/translation.js
@@ -1,9 +1,17 @@
-/*This javascript script translate (in this case from italian to french) layers and groups names, the title of the project, 
+/*This javascript script translate (in this case from inputLang to french) layers and groups names, the title of the project, 
 the print layout name and the aliases or fileds names according to the language of the browser and using the json file created
 with the python script get_translatable_string.py
 If a translated string is provided in the json file the original string is translated, otherwise the original string is shown.
-The json file must be saved in the media folder which need to be available from the web. To do this it is necessary to create 
-a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository.*/
+The json file must be saved in the media folder.*/
+
+var json_url = OpenLayers.Util.urlAppend(
+     lizUrls.media,
+     OpenLayers.Util.getParameterString({
+         "repository": lizUrls.params.repository,
+         "project": lizUrls.params.project,
+         "path": "media/translation.json"
+     })
+);
 
 //This function is executed when the uicreated event is triggered
 lizMap.events.on({
@@ -12,74 +20,74 @@ lizMap.events.on({
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){      
             
-            var translationIT_FR = {};
+            var translated_string = {};
 
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+            fetch(json_url).then(function(response) {
                 if (response.ok)
                     return response.json();
                 throw new Error('Network response was not ok.');
                 }).then(function(translation) {
 
                     // put the json content in to the dictionary
-                    translationIT_FR = translation;
-                    //console.log(translationIT_FR);
+                    translated_string = translation;
+                    //console.log(translated_string);
                     // iterate over dictionary key
-                    Object.keys(translationIT_FR).forEach((italian) => {
+                    Object.keys(translated_string).forEach((inputLang) => {
                         //check if a translation is provided for each string
-                        if (translationIT_FR[italian] != ""){
+                        if (translated_string[inputLang] != ""){
                             // translate layers and groups name in the layer tree
                             $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td span.label").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                             // translate layers name in the baselayer menu
                             $("div#content div#switcher.tab-pane div#switcher-baselayer.baselayer div.menu-content div.baselayer-select select option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                             // translate layers name in the editing tool menu
                             $("div#content div#edition.tab-pane div.edition div.menu-content div select option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                             // translate layers name in the selection tool menu
                             $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#selectiontool.tab-pane div.selectiontool div.menu-content table tbody tr td select#selectiontool-layer-list option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                             // translate layouts name in the print tool menu
                             $("div#content div#mini-dock div#print.tab-pane div.print div.menu-content table tbody tr td select#print-template option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
-                            // translate layers and groups name in the attribute layer tool
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
+                            // translate layers and groups name in the attribut layer tool menu
                             $("div#content div#bottom-dock div#attributeLayers.tab-pane div.tab-content div#attribute-layer-list table tbody tr td").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                             // translate the title of the project
                             $("div#header div#title h1").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                         }
                         else {
                             $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td span.label").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#switcher.tab-pane div#switcher-baselayer.baselayer div.menu-content div.baselayer-select select option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#edition.tab-pane div.edition div.menu-content div select option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#selectiontool.tab-pane div.selectiontool div.menu-content table tbody tr td select#selectiontool-layer-list option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#mini-dock div#print.tab-pane div.print div.menu-content table tbody tr td select#print-template option").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#bottom-dock div#attributeLayers.tab-pane div.tab-content div#attribute-layer-list table tbody tr td").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#header div#title h1").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                         }
                     });
             });
@@ -95,39 +103,39 @@ lizMap.events.on({
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){
 
-            var translationIT_FR2 = {};
+            var translated_string2 = {};
 
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+            fetch(json_url).then(function(response) {
                 if (response.ok)
                     return response.json();
                 throw new Error('Network response was not ok.');
                 }).then(function(translation) {
 
                     // put the json content in to the dictionary
-                    translationIT_FR2 = translation;
-                    //console.log(translationIT_FR2);
+                    translated_string2 = translation;
+                    //console.log(translated_string2);
                     // iterate over dictionary key
-                    Object.keys(translationIT_FR2).forEach((italian) => {
+                    Object.keys(translated_string2).forEach((inputLang) => {
                         //check if a translation is provided for each string
-                        if (translationIT_FR2[italian] != ""){
+                        if (translated_string2[inputLang] != ""){
                             // translate layers name in the edition form
                             $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR2[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string2[inputLang]);
                             // translate aliases or fields name in the edition form
                             $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR2[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string2[inputLang]);
                         }
                         else {
                             $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                         }
                     });
             });
@@ -143,39 +151,39 @@ lizMap.events.on({
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){
 
-            var translationIT_FR3 = {};
+            var translated_string3 = {};
 
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+            fetch(json_url).then(function(response) {
                 if (response.ok)
                     return response.json();
                 throw new Error('Network response was not ok.');
                 }).then(function(translation) {
 
                     // put the json content in to the dictionary
-                    translationIT_FR3 = translation;
-                    //console.log(translationIT_FR3);
+                    translated_string3 = translation;
+                    //console.log(translated_string3);
                     // iterate over dictionary key
-                    Object.keys(translationIT_FR3).forEach((italian) => {
+                    Object.keys(translated_string3).forEach((inputLang) => {
                         //check if a translation is provided for each string
-                        if (translationIT_FR3[italian] != ""){
+                        if (translated_string3[inputLang] != ""){
                             // translate layers name in the popup
                             $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR3[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string3[inputLang]);
                             // translate aliases or fields name in the popup
                             $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR3[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string3[inputLang]);
                         }
                         else {
                             $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                             $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                         }
                     });
             });
@@ -200,32 +208,32 @@ lizMap.events.on({
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){        
             
-            var translationIT_FR = {};
+            var translated_string = {};
 
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+            fetch(json_url).then(function(response) {
                 if (response.ok)
                     return response.json();
                 throw new Error('Network response was not ok.');
                 }).then(function(translation) {
 
                     // put the json content in to the dictionary
-                    translationIT_FR = translation;
-                    console.log(translationIT_FR);
+                    translated_string = translation;
+                    console.log(translated_string);
                     // iterate over dictionary key
-                    Object.keys(translationIT_FR).forEach((italian) => {
+                    Object.keys(translated_string).forEach((inputLang) => {
                         //check if a translation is provided for each string
-                        if (translationIT_FR[italian] != ""){
+                        if (translated_string[inputLang] != ""){
                             // translate the content of the layer information sub-dock
                             $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                         }
                         else{
                             $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                         }
                     });
                 });
@@ -240,29 +248,29 @@ lizMap.events.on({
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){    
             
-            var translationIT_FR = {};
+            var translated_string = {};
 
             // get the json file with transalted names
-            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+            fetch(json_url).then(function(response) {
                 if (response.ok)
                     return response.json();
                 throw new Error('Network response was not ok.');
                 }).then(function(translation) {
 
                     // put the json content in to the dictionary
-                    translationIT_FR = translation;
-                    console.log(translationIT_FR);
+                    translated_string = translation;
+                    console.log(translated_string);
                     // iterate over dictionary key
-                    Object.keys(translationIT_FR).forEach((italian) => {
-                        if (translationIT_FR[italian] != ""){
+                    Object.keys(translated_string).forEach((inputLang) => {
+                        if (translated_string[inputLang] != ""){
                             $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td div.tooltip div.tooltip-inner").filter(function(){
-                                return $(this).text() === italian
-                            }).html(translationIT_FR[italian]);
+                                return $(this).text() === inputLang
+                            }).html(translated_string[inputLang]);
                         }
                         else{
                             $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td div.tooltip div.tooltip-inner").filter(function(){
-                                return $(this).text() === italian
-                            }).html(italian);
+                                return $(this).text() === inputLang
+                            }).html(inputLang);
                         }
                     });
                 });

--- a/translation/translation.js
+++ b/translation/translation.js
@@ -6,6 +6,13 @@ The json file must be saved in the media folder.*/
 
 var translated_string = {};
 
+// get browser language
+var userLang = navigator.language || navigator.userLanguage;
+// to be changed with the desired language ID code
+var langId = 'fr'
+// to be changed with the desired language ID code + country (e.g. fr-FR = French (France), fr-BE = French (Belgium), etc.)
+var langIdCountry = 'fr-FR'
+
 var json_url = OpenLayers.Util.urlAppend(
      lizUrls.media,
      OpenLayers.Util.getParameterString({
@@ -18,10 +25,7 @@ var json_url = OpenLayers.Util.urlAppend(
 //This function is executed when the uicreated event is triggered
 lizMap.events.on({
     uicreated: function(e) {
-        // get browser language
-        var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){
-
+        if (userLang === langId || userLang === langIdCountry){
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
             fetch(json_url).then(function(response) {
@@ -99,9 +103,7 @@ lizMap.events.on({
 //This function is executed when the lizmapeditionformdisplayed event is triggered
 lizMap.events.on({
     lizmapeditionformdisplayed: function(e) {
-        // get browser language
-        var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){
+        if (userLang === langId || userLang === langIdCountry){
             //console.log(translated_string);
             // iterate over dictionary key
             Object.keys(translated_string).forEach((inputLang) => {
@@ -132,9 +134,7 @@ lizMap.events.on({
 //This function is executed when the lizmappopupdisplayed event is triggered
 lizMap.events.on({
     lizmappopupdisplayed: function(e) {
-        // get browser language
-        var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){
+        if (userLang === langId || userLang === langIdCountry){
                     // iterate over dictionary key
             Object.keys(translated_string).forEach((inputLang) => {
                 //check if a translation is provided for each string
@@ -164,8 +164,7 @@ lizMap.events.on({
 //This function is executed when the minidockopened event is triggered (it works only if the location tool is opened clicking on the related button of the toolbar)
 lizMap.events.on({
     minidockopened: function(){
-        var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){
+        if (userLang === langId || userLang === langIdCountry){
             // translate the layer name shown in the location tool 
             $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#locate.tab-pane.active div.locate div.menu-content div.locate-layer span.custom-combobox input[placeholder='Comuni Roia']").attr("placeholder", "Vive la revolucion");
         }
@@ -175,8 +174,7 @@ lizMap.events.on({
 //This function is executed when the lizmapswitcheritemselected event is triggered
 lizMap.events.on({
     lizmapswitcheritemselected: function(){
-        var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){         
+        if (userLang === langId || userLang === langIdCountry){         
             //console.log(translated_string);
             // iterate over dictionary key
             Object.keys(translated_string).forEach((inputLang) => {
@@ -201,8 +199,7 @@ lizMap.events.on({
 /*lizMap.events.on({
     mouseover: function(){
         console.log('Ciao!')
-        var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){
+        if (userLang === langId || userLang === langIdCountry){
                     // iterate over dictionary key
                     Object.keys(translated_string).forEach((inputLang) => {
                         if (translated_string[inputLang] != ""){

--- a/translation/translation.js
+++ b/translation/translation.js
@@ -49,7 +49,7 @@ lizMap.events.on({
                             $("div#content div#mini-dock div#print.tab-pane div.print div.menu-content table tbody tr td select#print-template option").filter(function(){
                                 return $(this).text() === italian
                             }).html(translationIT_FR[italian]);
-                            // translate layers and groups name in the layer tree
+                            // translate layers and groups name in the attribute layer tool
                             $("div#content div#bottom-dock div#attributeLayers.tab-pane div.tab-content div#attribute-layer-list table tbody tr td").filter(function(){
                                 return $(this).text() === italian
                             }).html(translationIT_FR[italian]);
@@ -125,7 +125,6 @@ lizMap.events.on({
                             $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
                                 return $(this).text() === italian
                             }).html(italian);
-                            // translate aliases or fields name in the edition form
                             $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
                                 return $(this).text() === italian
                             }).html(italian);

--- a/translation/translation.js
+++ b/translation/translation.js
@@ -1,0 +1,272 @@
+/*This javascript script translate (in this case from italian to french) layers and groups names, the title of the project, 
+the print layout name and the aliases or fileds names according to the language of the browser and using the json file created
+with the python script get_translatable_string.py
+If a translated string is provided in the json file the original string is translated, otherwise the original string is shown.
+The json file must be saved in the media folder which need to be available from the web. To do this it is necessary to create 
+a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository.*/
+
+//This function is executed when the uicreated event is triggered
+lizMap.events.on({
+    uicreated: function(e) {
+        // get browser language
+        var userLang = navigator.language || navigator.userLanguage;
+        if (userLang === 'fr' || userLang === 'fr-FR'){      
+            
+            var translationIT_FR = {};
+
+            // get the json file with transalted strings
+            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
+            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+                if (response.ok)
+                    return response.json();
+                throw new Error('Network response was not ok.');
+                }).then(function(translation) {
+
+                    // put the json content in to the dictionary
+                    translationIT_FR = translation;
+                    //console.log(translationIT_FR);
+                    // iterate over dictionary key
+                    Object.keys(translationIT_FR).forEach((italian) => {
+                        //check if a translation is provided for each string
+                        if (translationIT_FR[italian] != ""){
+                            // translate layers and groups name in the layer tree
+                            $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td span.label").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                            // translate layers name in the baselayer menu
+                            $("div#content div#switcher.tab-pane div#switcher-baselayer.baselayer div.menu-content div.baselayer-select select option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                            // translate layers name in the editing tool menu
+                            $("div#content div#edition.tab-pane div.edition div.menu-content div select option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                            // translate layers name in the selection tool menu
+                            $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#selectiontool.tab-pane div.selectiontool div.menu-content table tbody tr td select#selectiontool-layer-list option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                            // translate layouts name in the print tool menu
+                            $("div#content div#mini-dock div#print.tab-pane div.print div.menu-content table tbody tr td select#print-template option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                            // translate layers and groups name in the layer tree
+                            $("div#content div#bottom-dock div#attributeLayers.tab-pane div.tab-content div#attribute-layer-list table tbody tr td").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                            // translate the title of the project
+                            $("div#header div#title h1").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                        }
+                        else {
+                            $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td span.label").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#content div#switcher.tab-pane div#switcher-baselayer.baselayer div.menu-content div.baselayer-select select option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#content div#edition.tab-pane div.edition div.menu-content div select option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#selectiontool.tab-pane div.selectiontool div.menu-content table tbody tr td select#selectiontool-layer-list option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#content div#mini-dock div#print.tab-pane div.print div.menu-content table tbody tr td select#print-template option").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#content div#bottom-dock div#attributeLayers.tab-pane div.tab-content div#attribute-layer-list table tbody tr td").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#header div#title h1").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                        }
+                    });
+            });
+
+        }
+    }
+});
+
+//This function is executed when the lizmapeditionformdisplayed event is triggered
+lizMap.events.on({
+    lizmapeditionformdisplayed: function(e) {
+        // get browser language
+        var userLang = navigator.language || navigator.userLanguage;
+        if (userLang === 'fr' || userLang === 'fr-FR'){
+
+            var translationIT_FR2 = {};
+
+            // get the json file with transalted strings
+            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
+            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+                if (response.ok)
+                    return response.json();
+                throw new Error('Network response was not ok.');
+                }).then(function(translation) {
+
+                    // put the json content in to the dictionary
+                    translationIT_FR2 = translation;
+                    //console.log(translationIT_FR2);
+                    // iterate over dictionary key
+                    Object.keys(translationIT_FR2).forEach((italian) => {
+                        //check if a translation is provided for each string
+                        if (translationIT_FR2[italian] != ""){
+                            // translate layers name in the edition form
+                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR2[italian]);
+                            // translate aliases or fields name in the edition form
+                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR2[italian]);
+                        }
+                        else {
+                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            // translate aliases or fields name in the edition form
+                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                        }
+                    });
+            });
+
+        }
+    }
+});
+
+//This function is executed when the lizmappopupdisplayed event is triggered
+lizMap.events.on({
+    lizmappopupdisplayed: function(e) {
+        // get browser language
+        var userLang = navigator.language || navigator.userLanguage;
+        if (userLang === 'fr' || userLang === 'fr-FR'){
+
+            var translationIT_FR3 = {};
+
+            // get the json file with transalted strings
+            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
+            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+                if (response.ok)
+                    return response.json();
+                throw new Error('Network response was not ok.');
+                }).then(function(translation) {
+
+                    // put the json content in to the dictionary
+                    translationIT_FR3 = translation;
+                    //console.log(translationIT_FR3);
+                    // iterate over dictionary key
+                    Object.keys(translationIT_FR3).forEach((italian) => {
+                        //check if a translation is provided for each string
+                        if (translationIT_FR3[italian] != ""){
+                            // translate layers name in the popup
+                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR3[italian]);
+                            // translate aliases or fields name in the popup
+                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR3[italian]);
+                        }
+                        else {
+                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                        }
+                    });
+            });
+        }
+    }
+});
+
+//This function is executed when the minidockopened event is triggered (it works only if the location tool is opened clicking on the related button of the toolbar)
+lizMap.events.on({
+    minidockopened: function(){
+        var userLang = navigator.language || navigator.userLanguage;
+        if (userLang === 'fr' || userLang === 'fr-FR'){
+            // translate the layer name shown in the location tool 
+            $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#locate.tab-pane.active div.locate div.menu-content div.locate-layer span.custom-combobox input[placeholder='Comuni Roia']").attr("placeholder", "Vive la revolucion");
+        }
+    }
+});
+
+//This function is executed when the lizmapswitcheritemselected event is triggered
+lizMap.events.on({
+    lizmapswitcheritemselected: function(){
+        var userLang = navigator.language || navigator.userLanguage;
+        if (userLang === 'fr' || userLang === 'fr-FR'){        
+            
+            var translationIT_FR = {};
+
+            // get the json file with transalted strings
+            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
+            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+                if (response.ok)
+                    return response.json();
+                throw new Error('Network response was not ok.');
+                }).then(function(translation) {
+
+                    // put the json content in to the dictionary
+                    translationIT_FR = translation;
+                    console.log(translationIT_FR);
+                    // iterate over dictionary key
+                    Object.keys(translationIT_FR).forEach((italian) => {
+                        //check if a translation is provided for each string
+                        if (translationIT_FR[italian] != ""){
+                            // translate the content of the layer information sub-dock
+                            $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                        }
+                        else{
+                            $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                        }
+                    });
+                });
+        }
+    }
+});
+
+// Work in progress: translate the layer tooltip that is shown when the mouse pointer pass over the layer name in the layer tree (see issue https://github.com/3liz/lizmap-web-client/issues/428)
+/*lizMap.events.on({
+    mouseover: function(){
+        console.log('Ciao!')
+        var userLang = navigator.language || navigator.userLanguage;
+        if (userLang === 'fr' || userLang === 'fr-FR'){    
+            
+            var translationIT_FR = {};
+
+            // get the json file with transalted names
+            fetch('../../../../../../concerteaux3d/translation.json').then(function(response) {
+                if (response.ok)
+                    return response.json();
+                throw new Error('Network response was not ok.');
+                }).then(function(translation) {
+
+                    // put the json content in to the dictionary
+                    translationIT_FR = translation;
+                    console.log(translationIT_FR);
+                    // iterate over dictionary key
+                    Object.keys(translationIT_FR).forEach((italian) => {
+                        if (translationIT_FR[italian] != ""){
+                            $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td div.tooltip div.tooltip-inner").filter(function(){
+                                return $(this).text() === italian
+                            }).html(translationIT_FR[italian]);
+                        }
+                        else{
+                            $("div#content div#switcher.tab-pane div#switcher-layers-container.switcher div.menu-content div#switcher-layers div.without-blocks.no-group table.tree.treeTable tbody tr td div.tooltip div.tooltip-inner").filter(function(){
+                                return $(this).text() === italian
+                            }).html(italian);
+                        }
+                    });
+                });
+        }
+    }
+});*/

--- a/translation/translation.js
+++ b/translation/translation.js
@@ -1,31 +1,38 @@
-/*This javascript script translate (in this case from inputLang to french) layers and groups names, the title of the project, 
-the print layout name and the aliases or fileds names according to the language of the browser and using the json file created
+/*This javascript script translate layers and groups names, the title of the project, 
+the print layout name and the aliases or fileds names according to the language of the browser and using the json files created
 with the python script get_translatable_string.py
 If a translated string is provided in the json file the original string is translated, otherwise the original string is shown.
 The json file must be saved in the media folder.*/
 
 var translated_string = {};
+var langId = ''
 
+var check_lang = 0
 // get browser language
 var userLang = navigator.language || navigator.userLanguage;
 // to be changed with the desired language ID code
-var langId = 'fr'
-// to be changed with the desired language ID code + country (e.g. fr-FR = French (France), fr-BE = French (Belgium), etc.)
-var langIdCountry = 'fr-FR'
+if (userLang === 'fr' || userLang === 'fr-FR'){
+    langId = 'fr'
+    check_lang++;
+}
+else if (userLang === 'en' || userLang === 'en-EN'){
+    langId = 'en'
+    check_lang++;
+}
 
 var json_url = OpenLayers.Util.urlAppend(
      lizUrls.media,
      OpenLayers.Util.getParameterString({
          "repository": lizUrls.params.repository,
          "project": lizUrls.params.project,
-         "path": "media/translation.json"
+         "path": "media/translation_"+langId+".json"
      })
 );
 
 //This function is executed when the uicreated event is triggered
 lizMap.events.on({
     uicreated: function(e) {
-        if (userLang === langId || userLang === langIdCountry){
+        if (check_lang === 1){
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
             fetch(json_url).then(function(response) {
@@ -103,7 +110,7 @@ lizMap.events.on({
 //This function is executed when the lizmapeditionformdisplayed event is triggered
 lizMap.events.on({
     lizmapeditionformdisplayed: function(e) {
-        if (userLang === langId || userLang === langIdCountry){
+        if (check_lang === 1){
             //console.log(translated_string);
             // iterate over dictionary key
             Object.keys(translated_string).forEach((inputLang) => {
@@ -134,7 +141,7 @@ lizMap.events.on({
 //This function is executed when the lizmappopupdisplayed event is triggered
 lizMap.events.on({
     lizmappopupdisplayed: function(e) {
-        if (userLang === langId || userLang === langIdCountry){
+        if (check_lang === 1){
                     // iterate over dictionary key
             Object.keys(translated_string).forEach((inputLang) => {
                 //check if a translation is provided for each string
@@ -148,7 +155,8 @@ lizMap.events.on({
                         return $(this).text() === inputLang
                     }).html(translated_string[inputLang]);
                 }
-                else {
+                else {
+
                     $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
                         return $(this).text() === inputLang
                     }).html(inputLang);
@@ -164,7 +172,7 @@ lizMap.events.on({
 //This function is executed when the minidockopened event is triggered (it works only if the location tool is opened clicking on the related button of the toolbar)
 lizMap.events.on({
     minidockopened: function(){
-        if (userLang === langId || userLang === langIdCountry){
+        if (check_lang === 1){
             // translate the layer name shown in the location tool 
             $("div#content div#map-content div#mini-dock div.tabbable.tabs-below div#mini-dock-content.tab-content div#locate.tab-pane.active div.locate div.menu-content div.locate-layer span.custom-combobox input[placeholder='Comuni Roia']").attr("placeholder", "Vive la revolucion");
         }
@@ -174,7 +182,7 @@ lizMap.events.on({
 //This function is executed when the lizmapswitcheritemselected event is triggered
 lizMap.events.on({
     lizmapswitcheritemselected: function(){
-        if (userLang === langId || userLang === langIdCountry){         
+        if (check_lang === 1){         
             //console.log(translated_string);
             // iterate over dictionary key
             Object.keys(translated_string).forEach((inputLang) => {
@@ -199,7 +207,7 @@ lizMap.events.on({
 /*lizMap.events.on({
     mouseover: function(){
         console.log('Ciao!')
-        if (userLang === langId || userLang === langIdCountry){
+        if (check_lang === 1){
                     // iterate over dictionary key
                     Object.keys(translated_string).forEach((inputLang) => {
                         if (translated_string[inputLang] != ""){

--- a/translation/translation.js
+++ b/translation/translation.js
@@ -4,6 +4,8 @@ with the python script get_translatable_string.py
 If a translated string is provided in the json file the original string is translated, otherwise the original string is shown.
 The json file must be saved in the media folder.*/
 
+var translated_string = {};
+
 var json_url = OpenLayers.Util.urlAppend(
      lizUrls.media,
      OpenLayers.Util.getParameterString({
@@ -18,9 +20,7 @@ lizMap.events.on({
     uicreated: function(e) {
         // get browser language
         var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){      
-            
-            var translated_string = {};
+        if (userLang === 'fr' || userLang === 'fr-FR'){
 
             // get the json file with transalted strings
             // the path to the json file must be provided as relative path, using the web url the browser can return a security error
@@ -102,44 +102,29 @@ lizMap.events.on({
         // get browser language
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){
-
-            var translated_string2 = {};
-
-            // get the json file with transalted strings
-            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch(json_url).then(function(response) {
-                if (response.ok)
-                    return response.json();
-                throw new Error('Network response was not ok.');
-                }).then(function(translation) {
-
-                    // put the json content in to the dictionary
-                    translated_string2 = translation;
-                    //console.log(translated_string2);
-                    // iterate over dictionary key
-                    Object.keys(translated_string2).forEach((inputLang) => {
-                        //check if a translation is provided for each string
-                        if (translated_string2[inputLang] != ""){
-                            // translate layers name in the edition form
-                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(translated_string2[inputLang]);
-                            // translate aliases or fields name in the edition form
-                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(translated_string2[inputLang]);
-                        }
-                        else {
-                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(inputLang);
-                            $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(inputLang);
-                        }
-                    });
+            //console.log(translated_string);
+            // iterate over dictionary key
+            Object.keys(translated_string).forEach((inputLang) => {
+                //check if a translation is provided for each string
+                if (translated_string[inputLang] != ""){
+                    // translate layers name in the edition form
+                    $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(translated_string[inputLang]);
+                    // translate aliases or fields name in the edition form
+                    $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(translated_string[inputLang]);
+                }
+                else {
+                    $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container div h3").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(inputLang);
+                    $("div#content div#edition.tab-pane div.edition div.menu-content div#edition-form-container form#jforms_view_edition.form-horizontal div.control-group label").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(inputLang);
+                }
             });
-
         }
     }
 });
@@ -150,42 +135,27 @@ lizMap.events.on({
         // get browser language
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang === 'fr' || userLang === 'fr-FR'){
-
-            var translated_string3 = {};
-
-            // get the json file with transalted strings
-            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch(json_url).then(function(response) {
-                if (response.ok)
-                    return response.json();
-                throw new Error('Network response was not ok.');
-                }).then(function(translation) {
-
-                    // put the json content in to the dictionary
-                    translated_string3 = translation;
-                    //console.log(translated_string3);
                     // iterate over dictionary key
-                    Object.keys(translated_string3).forEach((inputLang) => {
-                        //check if a translation is provided for each string
-                        if (translated_string3[inputLang] != ""){
-                            // translate layers name in the popup
-                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(translated_string3[inputLang]);
-                            // translate aliases or fields name in the popup
-                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(translated_string3[inputLang]);
-                        }
-                        else {
-                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(inputLang);
-                            $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(inputLang);
-                        }
-                    });
+            Object.keys(translated_string).forEach((inputLang) => {
+                //check if a translation is provided for each string
+                if (translated_string[inputLang] != ""){
+                    // translate layers name in the popup
+                    $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(translated_string[inputLang]);
+                    // translate aliases or fields name in the popup
+                    $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(translated_string[inputLang]);
+                }
+                else {
+                    $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent h4").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(inputLang);
+                    $("div#content div#map-content div#map.olMap div#OpenLayers_Map_377_OpenLayers_ViewPort div#OpenLayers_Map_377_OpenLayers_Container div#liz_layer_popup.olPopup.lizmapPopup div#liz_layer_popup_GroupDiv div#liz_layer_popup_contentDiv.olPopupContent.lizmapPopupContent div.lizmapPopupDiv table.lizmapPopupTable tbody tr th").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(inputLang);
+                }
             });
         }
     }
@@ -206,37 +176,23 @@ lizMap.events.on({
 lizMap.events.on({
     lizmapswitcheritemselected: function(){
         var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){        
-            
-            var translated_string = {};
-
-            // get the json file with transalted strings
-            // the path to the json file must be provided as relative path, using the web url the browser can return a security error
-            fetch(json_url).then(function(response) {
-                if (response.ok)
-                    return response.json();
-                throw new Error('Network response was not ok.');
-                }).then(function(translation) {
-
-                    // put the json content in to the dictionary
-                    translated_string = translation;
-                    console.log(translated_string);
-                    // iterate over dictionary key
-                    Object.keys(translated_string).forEach((inputLang) => {
-                        //check if a translation is provided for each string
-                        if (translated_string[inputLang] != ""){
-                            // translate the content of the layer information sub-dock
-                            $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(translated_string[inputLang]);
-                        }
-                        else{
-                            $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
-                                return $(this).text() === inputLang
-                            }).html(inputLang);
-                        }
-                    });
-                });
+        if (userLang === 'fr' || userLang === 'fr-FR'){         
+            //console.log(translated_string);
+            // iterate over dictionary key
+            Object.keys(translated_string).forEach((inputLang) => {
+                //check if a translation is provided for each string
+                if (translated_string[inputLang] != ""){
+                    // translate the content of the layer information sub-dock
+                    $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(translated_string[inputLang]);
+                }
+                else{
+                    $("div#content div#sub-dock div.sub-metadata div.menu-content dl dd").filter(function(){
+                        return $(this).text() === inputLang
+                    }).html(inputLang);
+                }
+            });
         }
     }
 });
@@ -246,20 +202,7 @@ lizMap.events.on({
     mouseover: function(){
         console.log('Ciao!')
         var userLang = navigator.language || navigator.userLanguage;
-        if (userLang === 'fr' || userLang === 'fr-FR'){    
-            
-            var translated_string = {};
-
-            // get the json file with transalted names
-            fetch(json_url).then(function(response) {
-                if (response.ok)
-                    return response.json();
-                throw new Error('Network response was not ok.');
-                }).then(function(translation) {
-
-                    // put the json content in to the dictionary
-                    translated_string = translation;
-                    console.log(translated_string);
+        if (userLang === 'fr' || userLang === 'fr-FR'){
                     // iterate over dictionary key
                     Object.keys(translated_string).forEach((inputLang) => {
                         if (translated_string[inputLang] != ""){
@@ -273,7 +216,6 @@ lizMap.events.on({
                             }).html(inputLang);
                         }
                     });
-                });
         }
     }
 });*/


### PR DESCRIPTION
**Translation**
In this folder there are:

1. a python script to retrieve translatable strings from a QGIS project and its related .cfg file created with the lizmap plugin
2. a javascript file which translates the project content in Lizmap-Web-Client according to the browser language

**The python script (get_translatable_string.py)**
This python script retrieves all possible translatable strings (layers name, groups name, layouts name, fields or aliases name, etc.) from the QGIS project and the related .cfg file. It saves a json file in which the key is the retrieved string and the value should contain the translation of the string. The json file is automatically saved in the media folder. Following an example of the json structure:

`{"Original layer name": "", "Original group name": "", ..}`

The translation has to be provided manually by editing the file and putting the translated string in the double-quotes. Following an example of the translated json:

`{"Original layer name": "Translated layer name", "Original group name": "Translated group name", ..}`

**The js script (translation.js)**
This javascript script translates layers and groups names, the title of the project, the print layouts names and the aliases or fileds names according to the language of the browser and using the json file created with the python script get_translatable_string.py If a translated string is provided in the json file the original string is translated, otherwise the original string is shown in lizmap web client. The json file must be saved in the media folder which needs to be available from the web. Therefore it is necessary to create a symbolic link on the apache directory (e.g. /var/www/html/) to the media folder in the user repository. The javascript retrieves the original string (key) and the translated string (value) from the json file. Then for each key found in the jason check the text of the provided html selector (e.g. `$("div#header div#title h1")`). If the two strings (the one from the json file e the one found in the html page) match the text of the provided html selector is replaced with the translated string, if provided in the json file.

