### PR TITLE
Avoid basepath being repeated

### DIFF
--- a/library/ui/background_selector/background_selector.js
+++ b/library/ui/background_selector/background_selector.js
@@ -44,13 +44,9 @@ lizMap.events.on({
             var nextbl_val = nextbl.attr('value');
             var cur_image_url = $('#baselayer-image-selector').css('background-image');
             var cur_image_spl = cur_image_url.split('/');
-            var cur_image = cur_image_spl.pop();
+            cur_image_spl.pop();
             var nextbl_image = cur_image_spl.join('/') + '/' + nextbl_val + '.png';
-            var begin = window.location.protocol + "//" + window.location.host + "/";
-            nextbl_image = nextbl_image.replace(
-                begin,
-                lizUrls.basepath
-            ) + '")';
+
             $('#baselayer-image-selector')
                 .css(
                     'background-image',


### PR DESCRIPTION
I had basepath repeated with https://subdomain.lizmap.com/map/index.php/view/map/
In this case background-image was created as https://subdomain.lizmap.com/map/map/index.php/view/map/

@arno974 Hi, could you tell me if my fix is correct in your cases? Thanks.