### PR TITLE
prevent popups from opening when dropping gsv marker

### DIFF
--- a/library/api/google_street_view/google_street_view 3.8
+++ b/library/api/google_street_view/google_street_view 3.8
@@ -75,7 +75,8 @@ class LizGoogleStreeView {
 	    });
 
 	    this.mainLizmap.map.addInteraction(this._drawInteraction);
-
+        this._mainLizmap.popup.active = false;
+        
 	    this._drawInteraction.on('drawend', event => {
 	    	this.mainLizmap.map.removeInteraction(this._drawInteraction);
             this.mainLizmap.map.addInteraction(this._selectInteraction);
@@ -83,6 +84,9 @@ class LizGoogleStreeView {
             this._gsvFeature = event.feature;
             this.gsvSetPosition(this._gsvFeature.getGeometry());
             this.panorama.setVisible(true);
+            setTimeout(() => {
+              this._mainLizmap.popup.active = true;
+            }, "1000");
 	    });
 
 	    this._selectInteraction = new lizMap.ol.interaction.Select({wrapX: false,


### PR DESCRIPTION
Quick fix to stop popups from opening when dropping gsv marker.

* [ ] JavaScript are named according to the following pattern `my_own_feature_X.Y.js` where `X.Y` is the version of LWC used
* [ ] Include a `README.md` with a small picture/GIF of the feature

Funded by sponsored development