### PR TITLE
add gsv layer to toolLayer pool to be on top at all time

### DIFF
--- a/library/api/google_street_view/google_street_view_3.8.js
+++ b/library/api/google_street_view/google_street_view_3.8.js
@@ -63,8 +63,7 @@ class LizGoogleStreeView {
         this._gsvLayer.setProperties({
             name: 'google-street-view'
         });
-
-        this.mainLizmap.map.addLayer(this._gsvLayer);
+	this.mainLizmap.map.addToolLayer(this._gsvLayer);
     }
 
     activateStreetView(){


### PR DESCRIPTION
mainLizmap.map.addLayer doesn't allow the layer to be placed on top of raster layers.
use mainLizmap.map.addToolLayer instead to ensure it's top layer at all time.

* [ ] JavaScript are named according to the following pattern `my_own_feature_X.Y.js` where `X.Y` is the version of LWC used
* [ ] Include a `README.md` with a small picture/GIF of the feature

Funded by sponsored development