### PR TITLE
fix resizing gsv-pano when switching to media mode

### DIFF
--- a/library/api/google_street_view/google_street_view_3.8.js
+++ b/library/api/google_street_view/google_street_view_3.8.js
@@ -212,7 +212,10 @@ function initGoogleStreetView() {
                     var headerStyles = window.getComputedStyle(document.getElementById('header'));
                     // we are in the normal mode
                     height = (parseFloat(sidemenuStyles.height) * 45 / 100) - 15;
-                    width = ((parseFloat(headerStyles.width)-parseFloat(sidemenuStyles.width))  *  (parseFloat(minidockStyles.maxWidth)-1) / 100) -15;
+		    if (parseFloat(sidemenuStyles.width) > (parseFloat(headerStyles.width) * 30 /100))
+                	width = ((parseFloat(headerStyles.width))  *  (parseFloat(minidockStyles.maxWidth)-1) / 100) -15; // media
+                    else
+                        width = ((parseFloat(headerStyles.width)-parseFloat(sidemenuStyles.width))  *  (parseFloat(minidockStyles.maxWidth)-1) / 100) -15; // desktop
                 }
 
                 var gsvPano = document.getElementById('gsv-pano');


### PR DESCRIPTION
Trying to maximise gsv-pano width when switching to media mode. 

* [ ] JavaScript are named according to the following pattern `my_own_feature_X.Y.js` where `X.Y` is the version of LWC used
* [ ] Include a `README.md` with a small picture/GIF of the feature

Funded by sponsored development